### PR TITLE
add parameter to coerce non-numeric values to NaN during validation

### DIFF
--- a/pandas_schema/validation.py
+++ b/pandas_schema/validation.py
@@ -204,7 +204,7 @@ class InRangeValidation(_SeriesValidation):
         return 'was not in the range [{}, {})'.format(self.min, self.max)
 
     def validate(self, series: pd.Series) -> pd.Series:
-        series = pd.to_numeric(series)
+        series = pd.to_numeric(series, errors='coerce')
         return (series >= self.min) & (series < self.max)
 
 


### PR DESCRIPTION
Maybe this parameter should be exposed, but I set it to coerce by default. All non numeric values are converted into np.NaN elements. Without this setting validation raises an error if a string is found in a column of ints or floats.

Please let me know what you think