### PR TITLE
Avoid TypeError upon validation for InList

### DIFF
--- a/pandas_schema/validation.py
+++ b/pandas_schema/validation.py
@@ -375,7 +375,8 @@ class InListValidation(_SeriesValidation):
 
     @property
     def default_message(self):
-        return 'is not in the list of legal options ({})'.format(', '.join(self.options))
+        values = ','.join(str(v) for v in self.options)
+        return 'is not in the list of legal options ({})'.format(values)
 
     def validate(self, series: pd.Series) -> pd.Series:
         if self.case_sensitive:


### PR DESCRIPTION
@TMiguelT :
Fix for an error occuring when item in list to validate is int and not a string.
Entire error: 
'''
File "/anaconda3/lib/python3.6/site-packages/pandas_schema/validation.py", line 375, in default_message
    return 'is not in the list of legal options ({})'.format(', '.join(self.options))
TypeError: sequence item 0: expected str instance, int found
'''
This solution formats to string before concatenating.