### PR TITLE
Fix failing test `test.test_example.Example.test_example`.

### DIFF
--- a/pandas_schema/validation.py
+++ b/pandas_schema/validation.py
@@ -375,7 +375,7 @@ class InListValidation(_SeriesValidation):
 
     @property
     def default_message(self):
-        values = ','.join(str(v) for v in self.options)
+        values = ', '.join(str(v) for v in self.options)
         return 'is not in the list of legal options ({})'.format(values)
 
     def validate(self, series: pd.Series) -> pd.Series:


### PR DESCRIPTION
Missing spaces in the InListValidation default message caused the test
output to not match against expected output.