### PR TITLE
Contingent validation & optional columns

### DIFF
--- a/pandas_schema/column.py
+++ b/pandas_schema/column.py
@@ -5,7 +5,9 @@ from . import validation
 from .validation_warning import ValidationWarning
 
 class Column:
-    def __init__(self, name: str, validations: typing.Iterable['validation._BaseValidation'] = [], allow_empty=False):
+    def __init__(self, name: str, validations: typing.Iterable['validation._BaseValidation'] = [],
+                 allow_empty=False,
+                 optional=False):
         """
         Creates a new Column object
 
@@ -16,6 +18,7 @@ class Column:
         self.name = name
         self.validations = list(validations)
         self.allow_empty = allow_empty
+        self.optional = optional
 
     def validate(self, series: pd.Series) -> typing.List[ValidationWarning]:
         """

--- a/pandas_schema/schema.py
+++ b/pandas_schema/schema.py
@@ -73,7 +73,7 @@ class Schema:
             for column in columns_to_pair:
 
                 # Throw an error if the schema column isn't in the data frame
-                if column.name not in df:
+                if column.name not in df and not column.optional:
                     errors.append(ValidationWarning(
                         'The column {} exists in the schema but not in the data frame'.format(column.name)))
                     return errors

--- a/pandas_schema/validation.py
+++ b/pandas_schema/validation.py
@@ -90,7 +90,9 @@ class _SeriesValidation(_BaseValidation):
                 validated = ~series.isnull() & simple_validation
             else:
                 validated = (series.str.len() > 0) & simple_validation
-
+        elif column.optional:
+            if bool(series.isnull().all()) or list(series.unique()) == ['']:
+                validated = []
         else:
             validated = simple_validation
 

--- a/test/test_validation.py
+++ b/test/test_validation.py
@@ -660,6 +660,18 @@ class GetErrorTests(ValidationTestBase):
         errors = validator.get_errors(pd.Series(self.vals), Column('', allow_empty=False))
         self.assertEqual(len(errors), len(self.vals))
 
+    def test_in_range_optional_missing(self):
+        validator = InRangeValidation(min=0)
+        errors = validator.get_errors(pd.Series(), Column('', optional=True))
+
+        self.assertEqual(len(errors), 0)
+
+    def test_in_range_optional_with_error(self):
+        validator = InRangeValidation(min=4)
+        errors = validator.get_errors(pd.Series(self.vals), Column('', optional=False))
+
+        self.assertEqual(len(errors), len(self.vals))
+
 
 class PandasDtypeTests(ValidationTestBase):
     """


### PR DESCRIPTION
There is a use case for validation where we want to contingently validate a column. We might not require such a column, but will want to validate it if it happens to be provided. This would come up when PandasSchema is used in an 'ETL' pipeline where data is submitted by users or 3rd parties.

- If the column is _optional_ and present and at least one non-null value exists, validate as we do normally. 
- If the column is _optional_ and present but is empty, do not validate.
- If the column is _optional_ and not present, do not raise w/ the missing column exception.

I don't think _allow_empty_ has this behavior so I introduced a new parameter. It's close but it has subtly different behavior.

This might go against the design of the library in that all provided columns are considered required in the Schema. In which case, I guess this feature doesn't make sense.

Otherwise, I don't think this PR is ready to go (eg. more tests) but I'm happy to continue it so let me know what you think. Thx