### PR TITLE
ignore_nan for distinctvalues

### DIFF
--- a/pandas_schema/validation.py
+++ b/pandas_schema/validation.py
@@ -354,6 +354,10 @@ class IsDistinctValidation(_SeriesValidation):
     """
 
     def __init__(self, ignore_nan=False, **kwargs):
+        """
+        :param ignore_nan: Whether or not to ignore nan values when checking for distinct values in a column.
+        """
+
         super().__init__(**kwargs)
         self.ignore_nan = ignore_nan
 

--- a/pandas_schema/validation.py
+++ b/pandas_schema/validation.py
@@ -353,15 +353,19 @@ class IsDistinctValidation(_SeriesValidation):
     Checks that every element of this column is different from each other element
     """
 
-    def __init__(self, **kwargs):
+    def __init__(self, ignore_nan=False, **kwargs):
         super().__init__(**kwargs)
+        self.ignore_nan = ignore_nan
 
     @property
     def default_message(self):
         return 'contains values that are not unique'
 
     def validate(self, series: pd.Series) -> pd.Series:
-        return ~series.duplicated(keep='first')
+        if self.ignore_nan:
+            return ~series.duplicated(keep='first') | series.isna()
+        else:
+            return ~series.duplicated(keep='first')
 
 
 class InListValidation(_SeriesValidation):


### PR DESCRIPTION
Thanks for the great tool! :wave: 

Small & self-explanatory PR.

I added an argument to `IsDistinctValidation` called `ignore_nan` which when set to `True` does not take NaN values along when checking for duplicates.

Let me know if it needs extra work somewhere. 